### PR TITLE
Adding Sublime Text as Git editor

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -41,4 +41,10 @@ if [ ! -e "$HOME/.zshenv" ]; then
   touch "$HOME/.zshenv"
 fi
 
+source ~/.zshrc
+
+# Setting Sublime Text as main editor and git editor
+subl_path=`alias subl | grep -o '\(/[a-zA-Z0-9. ]\+\)\+'`
+git config --global core.editor "'$subl_path' -n -w"
+
 echo "You should quit and relaunch your terminal!"


### PR DESCRIPTION
Previously, typing `git commit` would bring up vim whish could be
a bit scary for students. This commit uses the `subl` alias provided
by oh-my-zsh to set the git editor to `subl -n -w` correctly.
