### PR TITLE
Enhancing the gitconfig

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -14,12 +14,12 @@
   remote = yellow
 
 [core]
-  editor = vim
-  pager = cat
+  editor = nano
+  pager = less -FRSX
 
 [alias]
   co = checkout
-  st = status
+  st = status -sb
   br = branch
   ci = commit
   fo = fetch origin
@@ -31,13 +31,19 @@
   sweep = !git branch --merged master | grep -v 'master$' | xargs git branch -d && git remote prune origin
 
   # http://www.jukie.net/bart/blog/pimping-out-git-log
-  lg = log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --date=relative
+  lg = log --graph --all --pretty=format:'%Cred%h%Creset - %s %Cgreen(%cr) %C(bold blue)%an%Creset %C(yellow)%d%Creset'
 
   # Serve local repo. http://coderwall.com/p/eybtga
   # Then other can access via `git clone git://#{YOUR_IP_ADDRESS}/
   serve = !git daemon --reuseaddr --verbose  --base-path=. --export-all ./.git
 
   m = checkout master
+
+  # Removes a file from the index
+  unstage = reset HEAD --
+
+[help]
+  autocorrect = 1
 
 [push]
 	default = simple


### PR DESCRIPTION
This commit changes the following settings.
## Editor:

The editor is now less -FRSX wish respect color codes and use a paging
mode only if the command output is longer than the screen. Pretty useful
for diff, log or lg commands.
## Status:

Adding -sb to git status. This will show the status in short version
which has proven to be more readable for students. It also displays the
distance (in commits) to the remote branch.
## Pretty log:

The log format is also cleaned up since --abbrev-commit and --date=relative
are already provided by %h and %cr respectively.

The branches list has been move to the end of the line to keep consistency
between lines.

Finally, the --all flag shows every branches and stashed commits.
## Autocorrect:

The help.autocorrect option tells git not to troll you by saying
'Did you mean git log' when you type 'git lgo' and other little mistakes.
## Unstage:

The git unstage alias was added to allow unstaging files that have been
added to the index. This is useful to "unadd" a file or unmark a
conflicting file.
