### PR TITLE
Changed the ~ sign to $HOME

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -14,7 +14,7 @@ export HOMEBREW_NO_ANALYTICS=1
 source "${ZSH}/oh-my-zsh.sh"
 
 # Load rbenv if installed
-export PATH="~/.rbenv/bin:${PATH}"
+export PATH="$HOME/.rbenv/bin:${PATH}"
 type -a rbenv > /dev/null && eval "$(rbenv init -)"
 
 # Rails and Ruby uses the local `bin` folder to store binstubs.

--- a/zshrc
+++ b/zshrc
@@ -14,7 +14,7 @@ export HOMEBREW_NO_ANALYTICS=1
 source "${ZSH}/oh-my-zsh.sh"
 
 # Load rbenv if installed
-export PATH="$HOME/.rbenv/bin:${PATH}"
+export PATH="${HOME}/.rbenv/bin:${PATH}"
 type -a rbenv > /dev/null && eval "$(rbenv init -)"
 
 # Rails and Ruby uses the local `bin` folder to store binstubs.


### PR DESCRIPTION
Had to do a reinstall of a student's laptop after their keyboard stopped working (failed ubuntu update). Previous setup didn't work until I changed the ~ to $HOME on line 17