### PR TITLE
Fix bundle open strange behaviour

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ cd "$CURRENT_DIR"
 setopt nocasematch
 if [[ ! `uname` =~ "darwin" ]]; then
   git config --global core.editor "subl -n -w $@ >/dev/null 2>&1"
-  echo 'export BUNDLER_EDITOR="subl $@ -a' >> zshrc
+  echo 'export BUNDLER_EDITOR="subl -a' >> zshrc
 else
   git config --global core.editor "'/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl' -n -w"
   bundler_editor="'/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl'"

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ cd "$CURRENT_DIR"
 setopt nocasematch
 if [[ ! `uname` =~ "darwin" ]]; then
   git config --global core.editor "subl -n -w $@ >/dev/null 2>&1"
-  echo 'export BUNDLER_EDITOR="subl $@ >/dev/null 2>&1"' >> zshrc
+  echo 'export BUNDLER_EDITOR="subl $@ -a' >> zshrc
 else
   git config --global core.editor "'/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl' -n -w"
   bundler_editor="'/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl'"


### PR DESCRIPTION
I use `bundle open gem_name` quite often, and I got tired of the behaviour it had with our current setup:

1. It opens a new Sublime window with the gem folder, instead of adding it to my
current Sublime window, alongside the project I'm working on when I try to access
this particular gem source code

2. It kept opening up two unsaved files `>/dev/null` `2>&1`, that I would have to
be careful not to save when closing the window 😅

I changed the BUNDLER_EDITOR env variable definition to use the -a option
from `subl` to get the following behavior.

`-a or --add:         Add folders to the current window`

I only did the changes for my system (OS X), as I'm not really familiar with Linux.
Could be nice to get the same on Linux, but I'm not sure the setup introduces the same
bugs.

And last, I did a quick check in bundler source code, BUNDLER_EDITOR seems to be
used exclusively to influence which editor would be used by `bundle open`. So I believe it's safe to change it.

What do you think of this modification?