### PR TITLE
skip symlinking of *.sublime-settings files in home directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ backup() {
 for name in *; do
   if [ ! -d "$name" ]; then
     target="$HOME/.$name"
-    if [[ ! "$name" =~ '\.sh$' ]] && [ "$name" != 'README.md' ]; then
+    if [[ ! "$name" =~ '\.sh$' ]] && [ "$name" != 'README.md' ] && [[ ! "$name" =~ '\.sublime-settings$' ]]; then
       backup $target
 
       if [ ! -e "$target" ]; then


### PR DESCRIPTION
No need to symlink these files in home directory, their purpose is to be symlinked in Sublime Text directories.