### PR TITLE
remove A File Icon

### DIFF
--- a/Package Control.sublime-settings
+++ b/Package Control.sublime-settings
@@ -1,7 +1,6 @@
 {
   "installed_packages":
   [
-    "A File Icon",
     "AdvancedNewFile",
     "All Autocomplete",
     "Babel",


### PR DESCRIPTION
Seems like all students have an error message about this plugin that can't be found.
Let's remove it to avoid too many tickets about that during setup days 👌 