### PR TITLE
add `BracketHighlighter` as default setup pack

### DIFF
--- a/Package Control.sublime-settings
+++ b/Package Control.sublime-settings
@@ -13,6 +13,7 @@
     "Package Control",
     "SCSS",
     "SublimeLinter",
-    "SublimeLinter-rubocop"
+    "SublimeLinter-rubocop",
+    "BracketHighlighter"
   ]
 }


### PR DESCRIPTION
More and more student is having unnecessary error for not closing their brackets, this additional package can help them to notice them easily