### PR TITLE
Add default pull reconciliation strategy for git

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -45,3 +45,6 @@
 
 [branch "master"]
   mergeoptions = --no-edit
+
+[pull]
+  rebase = false


### PR DESCRIPTION
Students experience a warning message when trying to pull from git, during AirBnB / Project.

This message is new to Git version 2.27.0, and this PR is just a way to enforce the previous git behaviour.

![image](https://user-images.githubusercontent.com/1598346/100847014-7c8c6a00-347f-11eb-8d20-84608db097df.png)
