### PR TITLE
remove virtualenv auto-loading

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -52,9 +52,8 @@ load-nvmrc
 # Same for `./node_modules/.bin` and nodejs
 export PATH="./bin:./node_modules/.bin:${PATH}:/usr/local/sbin"
 
-# Load 'lewagon' virtualenv for the Data Bootcamp. You can comment these 2 lines to disable this behavior.
+# Hide virtualenv for the Data Bootcamp
 export PYENV_VIRTUALENV_DISABLE_PROMPT=1
-pyenv activate lewagon 2>/dev/null && echo "🐍 Loading 'lewagon' virtualenv"
 
 # Store your own aliases in the ~/.aliases file and load the here.
 [[ -f "$HOME/.aliases" ]] && source "$HOME/.aliases"


### PR DESCRIPTION
this disables the virtualenv auto-loading as we are going to use `pyenv global` and `pyenv local` command to switch virtualenvs from a project to another. @barangerbenjamin @gmanchon please review. To be merged with https://github.com/lewagon/data-setup/pull/40