### PR TITLE
git clone zsh autosuggestions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,6 +33,7 @@ ZSH_PLUGINS_DIR="$HOME/.oh-my-zsh/custom/plugins"
 mkdir -p "$ZSH_PLUGINS_DIR" && cd "$ZSH_PLUGINS_DIR"
 if [ ! -d "$ZSH_PLUGINS_DIR/zsh-syntax-highlighting" ]; then
   echo "-----> Installing zsh plugin 'zsh-syntax-highlighting'..."
+  git clone https://github.com/zsh-users/zsh-autosuggestions
   git clone git://github.com/zsh-users/zsh-syntax-highlighting.git
 fi
 cd "$CURRENT_DIR"


### PR DESCRIPTION
This should fix the installation of the [zsh syntax highlighting](https://github.com/zsh-users/zsh-syntax-highlighting)