### PR TITLE
sort sublime package list

### DIFF
--- a/Package Control.sublime-settings
+++ b/Package Control.sublime-settings
@@ -4,7 +4,11 @@
     "A File Icon",
     "AdvancedNewFile",
     "All Autocomplete",
+    "Anaconda"
+    "AutoPEP8",
     "Babel",
+    "BracketHighlighter",
+    "Color Highlight",
     "Emmet",
     "ERB Snippets",
     "Git",
@@ -13,11 +17,7 @@
     "Package Control",
     "SCSS",
     "SublimeLinter",
-    "SublimeLinter-rubocop",
-    "BracketHighlighter",
-    "Color Highlight",
     "SublimeLinter-flake8",
-    "AutoPEP8",
-    "Anaconda"
+    "SublimeLinter-rubocop"
   ]
 }

--- a/zshrc
+++ b/zshrc
@@ -23,7 +23,14 @@ export PYENV_VIRTUALENV_DISABLE_PROMPT=1 # https://github.com/pyenv/pyenv-virtua
 type -a pyenv > /dev/null && eval "$(pyenv init -)" && eval "$(pyenv virtualenv-init -)" && RPROMPT+='[🐍 $(pyenv_prompt_info)]'
 
 # Load nvm (to manage your node versions)
-export NVM_DIR="$HOME/.nvm"
+if [ "$(uname 2> /dev/null)" != "Linux" ]
+then
+  # nvm bin path for macOS
+  export NVM_DIR="$HOME//usr/local/opt/nvm"
+else
+  # nvm bin path for Linux
+  export NVM_DIR="$HOME/.nvm"
+fi
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 


### PR DESCRIPTION
Students think they are missing some packages because they are not sorted alphabetically, like Sublime does. 

This PR sorts the package list. 

Other point I'm thinking about: 

Some of these packages are useful for web only, others are useful for data only. 

Shouldn't we have two version of this package list, one for each program? Just like we have two different setups. 

Or even two dotfiles versions since some other part of them are differing. For data, they don't need nvm, the tab size should be 4... 

What is your thought about this @ssaunier ? 