### PR TITLE
Don't load nvm function if nvm is not installed

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -45,8 +45,8 @@ load-nvmrc() {
     nvm use default --silent
   fi
 }
-add-zsh-hook chpwd load-nvmrc
-load-nvmrc
+type -a nvm > /dev/null && add-zsh-hook chpwd load-nvmrc
+type -a nvm > /dev/null && load-nvmrc
 
 # Rails and Ruby uses the local `bin` folder to store binstubs.
 # So instead of running `bin/rails` like the doc says, just run `rails`


### PR DESCRIPTION
Fix https://teamwagon.slack.com/archives/CPRHU0397/p1615076768006400
And https://lewagon-alumni.slack.com/archives/C015E0C601F/p1615166762127300

If `nvm` is not installed (web dev students not there yet in the setup, or data students), the `load-nvmrc` function is not going to be executed. 