### PR TITLE
add z and vscode plugins

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -4,7 +4,7 @@ ZSH=$HOME/.oh-my-zsh
 ZSH_THEME="robbyrussell"
 
 # Useful oh-my-zsh plugins for Le Wagon bootcamps
-plugins=(git gitfast last-working-dir common-aliases sublime zsh-syntax-highlighting history-substring-search pyenv)
+plugins=(git gitfast last-working-dir common-aliases sublime zsh-syntax-highlighting history-substring-search pyenv z vscode)
 
 # (macOS-only) Prevent Homebrew from reporting - https://github.com/Homebrew/brew/blob/master/docs/Analytics.md
 export HOMEBREW_NO_ANALYTICS=1


### PR DESCRIPTION
This adds [`z`](https://github.com/rupa/z) and [`vscode`](https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/vscode/vscode.plugin.zsh) plugins for `zsh`. 

`z` allows quick navigation through terminal.

`vscode` brings some aliases for VSCode to `zsh`.