### PR TITLE
[pyenv] handle the PATH for pyenv

### DIFF
--- a/profile
+++ b/profile
@@ -2,4 +2,4 @@
 # Setup the PATH for pyenv binaries and shims
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
-eval "$(pyenv init --path)"
+type -a pyenv > /dev/null && eval "$(pyenv init --path)"

--- a/profile
+++ b/profile
@@ -1,0 +1,5 @@
+
+# Setup the PATH for pyenv binaries and shims
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init --path)"


### PR DESCRIPTION
this PR adds a `~/.profile` file to the setup in order to handle the PATH manipulations for pyenv

## context

pyenv 2.0.0 introduced around May 2021 a [breaking change](https://github.com/pyenv/pyenv/blob/master/CHANGELOG.md) where the PATH is [no longer handled](https://github.com/pyenv/pyenv/issues/1649#issuecomment-694388530) by the `pyenv init`command

the solution proposed when running the `pyenv init` command is to handle the PATH for pyenv manually in the `~/.profile` file (where the user custom PATH manipulations are supposed to take place, not in the `~/.zshrc` file) :

``` bash
# (The below instructions are intended for common
# shell setups. See the README for more guidance
# if they don't apply and/or don't work for you.)

# Add pyenv executable to PATH and
# enable shims by adding the following
# to ~/.profile and ~/.zprofile:

export PYENV_ROOT="$HOME/.pyenv"
export PATH="$PYENV_ROOT/bin:$PATH"
eval "$(pyenv init --path)"

# Load pyenv into the shell by adding
# the following to ~/.zshrc:

eval "$(pyenv init -)"

# Make sure to restart your entire logon session
# for changes to profile files to take effect.
```
