### PR TITLE
Remove Ruby extension settings messing with the editor

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -71,13 +71,9 @@
     },
     "python.pythonPath": "~/.pyenv/shims/python",
     "python.formatting.provider": "yapf",
-    "ruby.useBundler": true,
-    "ruby.useLanguageServer": true,
-    "ruby.format": "rubocop",
     "ruby.lint":
     {
         "rubocop": true
     },
-    "ruby.intellisense": "rubyLocate",
     "workbench.startupEditor": "newUntitledFile"
 }


### PR DESCRIPTION
These options were messing with the editor UX, triggering unwanted behaviour... etc.
Removing them makes the experience way smoother, and keep the linting hints.