### PR TITLE
remove pyenv-virtualenv initialization

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -20,9 +20,8 @@ unalias rm # No interactive rm by default (brought by plugins/common-aliases)
 export PATH="${HOME}/.rbenv/bin:${PATH}" # Needed for Linux/WSL
 type -a rbenv > /dev/null && eval "$(rbenv init -)"
 
-# Load pyenv (to manage your Python versions)
+# Disable virtual environment automatic display
 export PYENV_VIRTUALENV_DISABLE_PROMPT=1
-type -a pyenv > /dev/null && eval "$(pyenv init -)" && eval "$(pyenv virtualenv-init -)" && RPROMPT+='[🐍 $(pyenv_prompt_info)]'
 
 # Load nvm (to manage your node versions)
 export NVM_DIR="$HOME/.nvm"


### PR DESCRIPTION
This removes automatic initialization of `pyenv-virtualenv` from the `zshrc` file as it is different for M1 chips. This option will be handled by the Data Setup virtual environment section https://github.com/lewagon/data-setup/blob/m1/_partials/virtualenv.md
