### PR TITLE
Add quoting to improve robustness

### DIFF
--- a/git_setup.sh
+++ b/git_setup.sh
@@ -4,8 +4,8 @@ read full_name
 echo "Type in your email address (the one used for your GitHub account): "
 read email
 
-git config --global user.email $email
-git config --global user.name $full_name
+git config --global user.email "$email"
+git config --global user.name "$full_name"
 
 git add .
 git commit --message "My identity for @lewagon in the gitconfig"


### PR DESCRIPTION
This will make git_setup.sh less likely to break in a confusing way should untoward input be provided.