### PR TITLE
add python specific vscode settings

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,14 +1,18 @@
 {
     "[python]":
     {
-        "editor.tabSize": 4
+        "editor.tabSize": 4,
+        "editor.guides.bracketPairs": false,
+        "editor.bracketPairColorization.enabled": false,
+        "editor.fontSize": 14,
+        "editor.formatOnPaste": false,
+        "editor.multiCursorModifier": "alt" // similar to jupyter
     },
     "editor.bracketPairColorization.enabled": true,
     "editor.detectIndentation": false,
     "editor.fontSize": 17,
     "editor.formatOnPaste": true,
     "editor.guides.bracketPairs": true,
-    "editor.insertSpaces": true,
     "editor.minimap.enabled": false,
     "editor.multiCursorModifier": "ctrlCmd",
     "editor.renderControlCharacters": true,
@@ -17,12 +21,9 @@
         80,
         120
     ],
-    "editor.scrollBeyondLastLine": true,
     "editor.showFoldingControls": "always",
     "editor.snippetSuggestions": "top",
     "editor.tabSize": 2,
-    "editor.trimAutoWhitespace": true,
-    "editor.useTabStops": true,
     "emmet.includeLanguages":
     {
         "erb": "html"
@@ -65,16 +66,13 @@
         "**/vendor/**": true
     },
     "git.enabled": false,
-    "python.formatting.provider": "yapf",
-    "python.pythonPath": "~/.pyenv/shims/python",
     "ruby.lint":
     {
         "rubocop": true
     },
-    "telemetry.enableCrashReporter": false,
-    "telemetry.enableTelemetry": false,
+    "telemetry.telemetryLevel": "off",
     "window.restoreWindows": "none",
-    "workbench.iconTheme": "vscode-great-icons",
+    "workbench.iconTheme": "material-icon-theme",
     "workbench.settings.editor": "json",
     "workbench.settings.openDefaultSettings": true,
     "workbench.settings.useSplitJSON": true,

--- a/settings.json
+++ b/settings.json
@@ -1,21 +1,13 @@
 {
     "[python]":
     {
-        "editor.tabSize": 4,
-        "editor.guides.bracketPairs": false,
         "editor.bracketPairColorization.enabled": false,
-        "editor.fontSize": 14,
-        "editor.formatOnPaste": false,
-        "editor.multiCursorModifier": "alt" // similar to jupyter
+        "editor.guides.bracketPairs": false,
+        "editor.tabSize": 4
     },
-    "python.defaultInterpreterPath": "~/.pyenv/shims/python",
-    "python.terminal.activateEnvironment": false,
-    "python.formatting.provider": "yapf",
-    
     "editor.bracketPairColorization.enabled": true,
     "editor.detectIndentation": false,
-    "editor.fontSize": 17,
-    "editor.formatOnPaste": true,
+    "editor.fontSize": 14,
     "editor.guides.bracketPairs": true,
     "editor.minimap.enabled": false,
     "editor.multiCursorModifier": "ctrlCmd",

--- a/settings.json
+++ b/settings.json
@@ -79,7 +79,7 @@
     },
     "telemetry.telemetryLevel": "off",
     "window.restoreWindows": "none",
-    "workbench.iconTheme": "material-icon-theme",
+    "workbench.iconTheme": "vscode-great-icons",
     "workbench.settings.editor": "json",
     "workbench.settings.openDefaultSettings": true,
     "workbench.settings.useSplitJSON": true,


### PR DESCRIPTION
Two things have been changed
- I've added python specific settings
- I've removed settings that were duplicating default VScode values

One problem remains: if we split the setting into two as I did, students will be confused when jumping from one language to another. Let's have a chat about why did we add so many new constrains beyond defaut VScode behavior. e.g.
- The default 17pt value for font size is so huge! Why?
- Why "editor.formatOnPaste:true"
- Why changed "editor.multiCursorModifier" default settings?
- ...

and see if we can find middle grouds that minimizes differences between python and ruby/default student settings