### PR TITLE
use ipdb as the default Python debugger

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -66,3 +66,6 @@ export LC_ALL=en_US.UTF-8
 
 export BUNDLER_EDITOR=code
 export EDITOR=code
+
+# Set ipdb as the default Python debugger
+export PYTHONBREAKPOINT=ipdb.set_trace


### PR DESCRIPTION
This set `ipdb` as the default Python debugger cf https://github.com/lewagon/data-solutions/pull/878 