### PR TITLE
Remove pyenv plugin

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -4,7 +4,7 @@ ZSH=$HOME/.oh-my-zsh
 ZSH_THEME="robbyrussell"
 
 # Useful oh-my-zsh plugins for Le Wagon bootcamps
-plugins=(git gitfast last-working-dir common-aliases zsh-syntax-highlighting history-substring-search pyenv)
+plugins=(git gitfast last-working-dir common-aliases zsh-syntax-highlighting history-substring-search)
 
 # (macOS-only) Prevent Homebrew from reporting - https://github.com/Homebrew/brew/blob/master/docs/Analytics.md
 export HOMEBREW_NO_ANALYTICS=1
@@ -23,7 +23,7 @@ type -a rbenv > /dev/null && eval "$(rbenv init -)"
 
 # Load pyenv (to manage your Python versions)
 export PYENV_VIRTUALENV_DISABLE_PROMPT=1
-type -a pyenv > /dev/null && eval "$(pyenv init -)" && eval "$(pyenv virtualenv-init -)" && RPROMPT+='[🐍 $(pyenv_prompt_info)]'
+type -a pyenv > /dev/null && eval "$(pyenv init -)" && eval "$(pyenv virtualenv-init -)" && RPROMPT+='[🐍 $(pyenv version-name)]'
 
 # Load nvm (to manage your node versions)
 export NVM_DIR="$HOME/.nvm"


### PR DESCRIPTION
It seems that we don't need the [`pyenv` plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/pyenv) which is causing troubles lately with some hints at `~/.zprofile` / `~/.profile`.

We have other lines in the configuration which already run the `pyenv init`. The plugin was just provided with the BASH function `pyenv_prompt_info` that can be easily replaced.

It works on my laptop, but to be extra sure, could you:

- [x] @dmilon test it on your Linux?
- [x] @krokrob test it on your macOS?
- [ ] @brunolajoie test it on our Virtual Machine setup (Codespace / GCP)?
- [ ] @gmanchon test it on something else I might have forgotten? (Windows B2B maybe?)

Thank you all 🙏 