### PR TITLE
vs code remove .venv folder from search

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -60,7 +60,6 @@
     "notebook.diff.ignoreMetadata": true,
     "notebook.lineNumbers": "on",
     "notebook.markup.fontSize": 13,
-    "python.defaultInterpreterPath": "~/.pyenv/shims/python",
     "python.formatting.provider": "yapf",
     "python.languageServer": "Pylance",
     "python.linting.enabled": false,
@@ -69,6 +68,10 @@
     "python.terminal.activateEnvironment": false,
     "ruby.lint": {
         "rubocop": true
+    },
+    "search.exclude": {
+      // Inherits all glob patterns from the `files.exclude` setting.
+      "**/.venv": true
     },
     "telemetry.telemetryLevel": "off",
     "window.restoreWindows": "none",

--- a/settings.json
+++ b/settings.json
@@ -60,6 +60,7 @@
     "notebook.diff.ignoreMetadata": true,
     "notebook.lineNumbers": "on",
     "notebook.markup.fontSize": 13,
+    "python.defaultInterpreterPath": "~/.pyenv/shims/python",
     "python.formatting.provider": "yapf",
     "python.languageServer": "Pylance",
     "python.linting.enabled": false,


### PR DESCRIPTION
This is needed for data-engineering-bootcamp where students will create their venv inside each challenge folder using `poetry install`

- We don't want to pollute their search
- But we don't want to hide the folder .venv altogether, it's better to see that it exists to understand what's happening