### PR TITLE
trimtrailingwhitespace moved back to false (default)

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -47,7 +47,6 @@
     "files.hotExit": "off",
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
-    "files.trimTrailingWhitespace": true,
     "files.watcherExclude": {
         "**/audits/**": true,
         "**/coverage/**": true,


### PR DESCRIPTION
Markdown text is sensitive to trailing whitespaces: A double whitespace at end of line equals a linebreak.

Forcing `trimtrailingwhitespace` to True was making our content creator create buggy challenge README.md content

I suggest to move it back to False (default)
