### PR TITLE
included command in `.zshrc` that eliminates duplicates in `$path`

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -58,6 +58,10 @@ type -a nvm > /dev/null && load-nvmrc
 # Same for `./node_modules/.bin` and nodejs
 export PATH="./bin:./node_modules/.bin:${PATH}:/usr/local/sbin"
 
+# the $path variable can get bloated after a while
+# this command makes sure that it only includes unique values
+typeset -U path
+
 # Store your own aliases in the ~/.aliases file and load the here.
 [[ -f "$HOME/.aliases" ]] && source "$HOME/.aliases"
 


### PR DESCRIPTION
This is related to https://github.com/lewagon/dotfiles/issues/140

---

Over time the $PATH variable can get quite bloated and have many duplicates inside.

`typeset -U path`

This takes care of this and checks `$path` to only include unique values e.g. it deletes all duplicates.

https://zsh.sourceforge.io/Guide/zshguide02.html#l24