### PR TITLE
Using less discriminatory language 

### DIFF
--- a/git_setup.sh
+++ b/git_setup.sh
@@ -9,7 +9,7 @@ git config --global user.name "$full_name"
 
 git add .
 git commit --message "My identity for @lewagon in the gitconfig"
-git push origin master
+git push origin main
 
 git remote add upstream git@github.com:lewagon/dotfiles.git
 

--- a/gitconfig
+++ b/gitconfig
@@ -51,11 +51,11 @@
 [push]
   default = simple
 
-[branch "master"]
+[branch "main"]
   mergeoptions = --no-edit
 
 [pull]
   rebase = false
 
 [init]
-  defaultBranch = master
+  defaultBranch = main


### PR DESCRIPTION
In tech, there has been a movement to use more inclusive as well as less discriminatory language. One example is github replacing the term "master" on its service with a neutral term like "main" to avoid any unnecessary references to slavery.

In this vein and in line with Le Wagon‘s attitude to not tolerate sexism, racism, homophobia, or any kind of discrimination, it would be appropriate to change the dotfiles to mirror that. This is a pull request to change this.