### PR TITLE
add pryrc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ symlink() {
 
 # For all files `$name` in the present folder except `*.sh`, `README.md`, `settings.json`,
 # and `config`, backup the target file located at `~/.$name` and symlink `$name` to `~/.$name`
-for name in aliases gitconfig irbrc rspec zprofile zshrc pryrc; do
+for name in aliases gitconfig irbrc pryrc rspec zprofile zshrc; do
   if [ ! -d "$name" ]; then
     target="$HOME/.$name"
     backup $target

--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ symlink() {
 
 # For all files `$name` in the present folder except `*.sh`, `README.md`, `settings.json`,
 # and `config`, backup the target file located at `~/.$name` and symlink `$name` to `~/.$name`
-for name in aliases gitconfig irbrc rspec zprofile zshrc; do
+for name in aliases gitconfig irbrc rspec zprofile zshrc pryrc; do
   if [ ! -d "$name" ]; then
     target="$HOME/.$name"
     backup $target

--- a/pryrc
+++ b/pryrc
@@ -1,0 +1,36 @@
+# https://github.com/pry/pry/tree/master/lib/pry
+
+if defined?(Rails)
+  short_env_name_options = {
+    'development' => 'dev',
+    'production'  => 'prod'
+  } 
+  app_name = Rails.application.class.module_parent_name.underscore.dasherize
+  env_name = short_env_name_options.fetch(Rails.env) { Rails.env }
+  description = 'Prompt has to match the rails app name'
+else
+  current_directory = Dir.pwd.split('/').last.to_s
+  description = 'Prompt has to match the current directory name'
+end
+
+# https://github.com/pry/pry/blob/master/lib/pry/prompt.rb
+Pry::Prompt.add(:current_app) do |context, nesting, pry_instance, sep|
+  format(
+    '[%<in_count>s] %<current_app>s(%<context>s)%<nesting>s%<separator>s ',
+    in_count: pry_instance.input_ring.count,
+    current_app: app_name || current_directory,
+    context: env_name || Pry.view_clip(context),
+    nesting: (nesting > 0 ? ":#{nesting}" : ''),
+    separator: sep
+  )
+end
+
+prompt = Pry::Prompt[:current_app]
+procs = [
+  proc { |*args| prompt.wait_proc.call(*args).to_s },
+  proc { |*args| prompt.incomplete_proc.call(*args).to_s }
+]
+
+Pry.config.prompt = Pry::Prompt.new(
+  'custom_app_prompt', description, procs
+)


### PR DESCRIPTION
Adding `pryrc` to have a `pry` / `irb` easier to read for students.

It is an echo to this [merged pr](https://github.com/rails/rails/pull/51705) to `rails`.
We also can colorize with something like this `Pry::Helpers::Text.red` for production but I don't think that is very neutral and the students should customize by themselves.

The rails config part is for the students that use `rails` with `pry-rails` inside their app (to not be lost just after the bootcamp).