### PR TITLE
Update alias speedtest to python3

### DIFF
--- a/aliases
+++ b/aliases
@@ -1,6 +1,6 @@
 # Get External IP / Internet Speed
 alias myip="curl https://ipinfo.io/json" # or /ip for plain-text ip
-alias speedtest="curl -s https://raw.githubusercontent.com/sivel/speedtest-cli/master/speedtest.py | python -"
+alias speedtest="curl -s https://raw.githubusercontent.com/sivel/speedtest-cli/master/speedtest.py | python3 -"
 
 # Quickly serve the current directory as HTTP
 alias serve='ruby -run -e httpd . -p 8000' # Or python -m SimpleHTTPServer :)


### PR DESCRIPTION
This pull request updates the speedtest alias to use python3 for improved compatibility with modern systems.
Tested on WSL and Ubuntu 24.04, A test should be done on macOS
